### PR TITLE
转让代码权限

### DIFF
--- a/OWNERSHIP-TRANSFER.md
+++ b/OWNERSHIP-TRANSFER.md
@@ -1,0 +1,65 @@
+# Source Code Copyright Assignment Agreement
+# 源代码版权转让协议
+
+**Assignor（转让方）**: AptS-1547 (GitHub username: [https://github.com/AptS-1547](https://github.com/AptS-1547))  
+**Assignee（受让方）**: cg8-5712 (GitHub username: [https://github.com/cg8-5712](https://github.com/cg8-5712))
+
+---
+
+## 1. Scope of Transfer | 转让范围
+
+The Assignor hereby irrevocably transfers to the Assignee **full and exclusive ownership** of all original code authored by the Assignor in the repository:
+
+🔗 [https://github.com/Bj35-Dev/Bj35-bot](https://github.com/Bj35-Dev/Bj35-bot)
+
+This includes all copyrights, rights to modify, distribute, relicense, publish, commercialize, or otherwise exploit said code.
+
+转让方在上述仓库中所编写的全部原创代码，其**完整和独占的所有权**，现正式转让予受让方，包括但不限于：
+
+- 著作权；
+- 修改权、复制权、再授权权；
+- 用于商业、竞赛、开源等任意用途的处置权。
+
+---
+
+## 2. Exclusion of Warranty | 免责声明
+
+The Assignor transfers the code **"as-is"**, with **no warranties** regarding quality, suitability, or non-infringement.
+
+转让方以 “原样” 状态提供代码，不对其质量、适用性或合法性承担任何明示或暗示的保证义务。
+
+---
+
+## 3. No Rights Retained | 不保留权利
+
+After this assignment, the Assignor **waives all rights and claims** to the assigned code.  
+The Assignor **may not revoke or reuse** the code under any personal license.
+
+本转让完成后，转让方不再对该代码拥有任何权利或权益，亦不得以任何形式撤销、收回或重复使用该代码。
+
+---
+
+## 4. Effective Date | 生效日期
+
+This assignment takes effect immediately upon publication or delivery.
+
+本转让协议自以下日期起生效：
+
+📅 **Date**: 2025-06-07
+
+---
+
+## 5. Signatures | 签名
+
+**Assignor (转让方)**  
+Name: AptS-1547  
+Email: apts-1547@esaps.net  
+GitHub: [https://github.com/AptS-1547](https://github.com/AptS-1547)
+
+**Assignee (受让方)**  
+Name: cg8-5712  
+GitHub: [https://github.com/cg8-5712](https://github.com/cg8-5712)
+
+✍️ _This document may be signed electronically or included in repository documentation as proof of assignment._
+
+_本文件可通过电子方式签署，或以文档形式附于仓库中作为转让凭证。_

--- a/OWNERSHIP-TRANSFER.md
+++ b/OWNERSHIP-TRANSFER.md
@@ -41,7 +41,7 @@ The Assignor **may not revoke or reuse** the code under any personal license.
 
 ## 4. Effective Date | 生效日期
 
-This assignment takes effect immediately upon publication or delivery.
+This assignment takes effect on the date specified below.
 
 本转让协议自以下日期起生效：
 


### PR DESCRIPTION
This pull request adds a detailed copyright assignment agreement to the `OWNERSHIP-TRANSFER.md` file. The agreement formalizes the transfer of ownership for all original code in the specified repository from one GitHub user to another.

Ownership transfer details:

* Added a comprehensive agreement specifying the scope of transfer, exclusion of warranty, and effective date for the ownership transfer of the repository `Bj35-bot`. The agreement ensures full and exclusive ownership rights are transferred from `AptS-1547` to `cg8-5712`.